### PR TITLE
Changing connection settings to work with Android 4

### DIFF
--- a/src/main/java/gov/adlnet/xapi/client/BaseClient.java
+++ b/src/main/java/gov/adlnet/xapi/client/BaseClient.java
@@ -86,11 +86,11 @@ public class BaseClient {
 	}
 	
 	protected HttpURLConnection initializePOSTConnection(URL url)
-         throws IOException {
-      HttpURLConnection conn = initializeConnection(url);
-      conn.setDoOutput(true);
-      return conn;
-   }
+			throws IOException {
+		HttpURLConnection conn = initializeConnection(url);
+		conn.setDoOutput(true);
+		return conn;
+	}
 
 	protected String issuePost(String path, String data)
 			throws java.io.IOException {


### PR DESCRIPTION
Android 4.x changes a connection to POST when setDoOutput(true)... made a separate initializeConnection for GET and POST
